### PR TITLE
Fix: Use file size in number

### DIFF
--- a/src/Utils/UploadHandler.php
+++ b/src/Utils/UploadHandler.php
@@ -2725,6 +2725,7 @@ class UploadHandler
     function getsize($size)
     {
         $last = strtolower($size{strlen($size) - 1});
+        $size = substr($size, 0, -1);
         switch ($last) {
             case 'g':
                 $size *= 1024;


### PR DESCRIPTION
**Old version:**

  2g  *= 1024;
  2m *= 1024;
  2k  *= 1024;

**Fixed:**

 2 *= 1024