### PR TITLE
Parse file size "b" to "kb"

### DIFF
--- a/src/Utils/UploadHandler.php
+++ b/src/Utils/UploadHandler.php
@@ -2223,7 +2223,7 @@ class UploadHandler
                             $this->file_src_name_ext  = '';
                             $this->file_src_name_body = $this->file_src_name;
                         }
-                        $this->file_src_size = (file_exists($this->file_src_pathname) ? filesize($this->file_src_pathname) : 0);
+                        $this->file_src_size = (file_exists($this->file_src_pathname) ? filesize($this->file_src_pathname) / 1024 : 0);
                     }
                     $this->file_src_error = 0;
                 } else {
@@ -2253,7 +2253,7 @@ class UploadHandler
                             $this->file_src_name_ext  = '';
                             $this->file_src_name_body = $this->file_src_name;
                         }
-                        $this->file_src_size = (file_exists($this->file_src_pathname) ? filesize($this->file_src_pathname) : 0);
+                        $this->file_src_size = (file_exists($this->file_src_pathname) ? filesize($this->file_src_pathname) / 1024 : 0);
                     }
                     $this->file_src_error = 0;
                 }


### PR DESCRIPTION
O limite máximo de tamanho do arquivo é em KB mas o tamanho do arquivo lido está em b. A ideia desse fix é utilizar as duas medidas em kb.